### PR TITLE
🛠️ Fixed setup.py Script

### DIFF
--- a/mobo_bot_teleop/setup.py
+++ b/mobo_bot_teleop/setup.py
@@ -11,19 +11,19 @@ setup(
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        # ('lib/' + package_name, [package_name+'/python_file.py']),
         (os.path.join('share', package_name), glob('launch/*launch.[pxy][yma]*')),
     ],
     install_requires=['setuptools'],
+    extras_require={
+        'test': ['pytest'],
+    },
     zip_safe=True,
     maintainer='samuko',
     maintainer_email='samuel.c.agba@gmail.com',
     description='TODO: Package description',
     license='TODO: License declaration',
-    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
-            # 'executable_name = package_name.python_file_name:main'
             'mobo_bot_teleop = mobo_bot_teleop.mobo_bot_teleop:main',
         ],
     },


### PR DESCRIPTION
Fix setup.py: Replace deprecated tests_require with extras_require for compatibility with modern setuptools.

![Screenshot from 2025-01-07 16-17-25](https://github.com/user-attachments/assets/b8b0aa1d-39c8-4886-8a85-6e4d9e8bcc5d)

![Screenshot from 2025-01-07 16-17-53](https://github.com/user-attachments/assets/971335c3-7be0-4611-b7d9-741f872ebd5e)

